### PR TITLE
store `target` to be used in detached

### DIFF
--- a/paper-tooltip.html
+++ b/paper-tooltip.html
@@ -42,6 +42,10 @@ Custom property | Description | Default
 `--paper-tooltip-opacity` | The opacity of the tooltip | `0.9`
 `--paper-tooltip-text-color` | The text color of the tooltip | `white`
 `--paper-tooltip` | Mixin applied to the tooltip | `{}`
+
+@group Paper Elements
+@element paper-tooltip
+@demo demo/index.html
 -->
 
 <dom-module id="paper-tooltip">
@@ -153,21 +157,21 @@ Custom property | Description | Default
       },
 
       attached: function() {
-        var target = this.target;
+        this._target = this.target;
 
-        this.listen(target, 'mouseenter', 'show');
-        this.listen(target, 'focus', 'show');
-        this.listen(target, 'mouseleave', 'hide');
-        this.listen(target, 'blur', 'hide');
+        this.listen(this._target, 'mouseenter', 'show');
+        this.listen(this._target, 'focus', 'show');
+        this.listen(this._target, 'mouseleave', 'hide');
+        this.listen(this._target, 'blur', 'hide');
       },
 
       detached: function() {
-        var target = this.target;
-        
-        this.unlisten(target, 'mouseenter', 'show');
-        this.unlisten(target, 'focus', 'show');
-        this.unlisten(target, 'mouseleave', 'hide');
-        this.unlisten(target, 'blur', 'hide');
+        if (this._target) {
+          this.unlisten(this._target, 'mouseenter', 'show');
+          this.unlisten(this._target, 'focus', 'show');
+          this.unlisten(this._target, 'mouseleave', 'hide');
+          this.unlisten(this._target, 'blur', 'hide');
+        }
       },
 
       show: function() {
@@ -184,9 +188,10 @@ Custom property | Description | Default
       },
 
       _setPosition: function() {
-        var target = this.target;
+        if (!this._target)
+          return;
 
-        var targetRect = target.getBoundingClientRect();
+        var targetRect = this._target.getBoundingClientRect();
         var thisRect = this.getBoundingClientRect();
 
         var centerOffset = (targetRect.width - thisRect.width) / 2;

--- a/test/basic.html
+++ b/test/basic.html
@@ -27,47 +27,69 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <test-fixture id="basic">
     <template>
-      <div id="target"></div>
-      <paper-tooltip for="target" id="tooltip">Tooltip text</paper-tooltip>
+      <div>
+        <div id="target"></div>
+        <paper-tooltip for="target">Tooltip text</paper-tooltip>
+      </div>
     </template>
   </test-fixture>
 
   <script>
     suite('basic', function() {
-      test('tooltip is shown when target is focused', function() {
-        var f = fixture('basic');
-        var target = f[0];
-        var tooltip = f[1].querySelector('#tooltip');
+      var f, tooltip, target;
 
-        assert.isTrue(tooltip.hidden);
+      setup(function() {
+        f = fixture('basic');
+        target = f.querySelector('#target');
+        tooltip = f.querySelector('paper-tooltip');
+      });
+
+      test('tooltip is shown when target is focused', function() {
+        var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
+        assert.isTrue(actualTooltip.hidden);
 
         MockInteractions.focus(target);
-        assert.isFalse(tooltip.hidden);
+        assert.isFalse(actualTooltip.hidden);
       });
 
       test('tooltip is hidden after target is blurred', function(done) {
-        var f = fixture('basic');
-        var target = f[0];
-        var tooltip = f[1].querySelector('#tooltip');
-
-        assert.isTrue(tooltip.hidden);
+        var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
+        assert.isTrue(actualTooltip.hidden);
         MockInteractions.focus(target);
-        assert.isFalse(tooltip.hidden);
+        assert.isFalse(actualTooltip.hidden);
 
-        f[1].addEventListener('neon-animation-finish', function() {
-          assert.isTrue(tooltip.hidden);
+        tooltip.addEventListener('neon-animation-finish', function() {
+          assert.isTrue(actualTooltip.hidden);
           done();
         });
         MockInteractions.blur(target);
+      });
 
+      test('tooltip unlistens to target on detach', function(done) {
+        sinon.spy(tooltip, 'show');
+
+        MockInteractions.focus(target);
+        expect(tooltip.show.callCount).to.be.equal(1);
+
+        MockInteractions.focus(target);
+        expect(tooltip.show.callCount).to.be.equal(2);
+
+        f.removeChild(tooltip);
+
+        setTimeout(function() {
+          // No more listener means no more calling show.
+          MockInteractions.focus(target);
+          expect(tooltip.show.callCount).to.be.equal(2);
+          done();
+        }, 200);
       });
     });
 
     suite('a11y', function() {
       test('has aria role "tooltip"', function() {
         var f = fixture('basic');
-        var target = f[0];
-        var tooltip = f[1];
+        var tooltip = f.querySelector('paper-tooltip');
+
         assert.isTrue(tooltip.getAttribute('role') == 'tooltip');
       });
     });


### PR DESCRIPTION
By the time `detached` is called, the tooltip no longer has a parent, so recomputing the `target()` makes no sense. And recomputing all the time doesn't make sense in general.

Also, added the correct demo annotations.

@cdata PTAL