### PR TITLE
fixes #13, #7, #18, #3

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -23,11 +23,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../paper-icon-button/paper-icon-button.html">
   <link rel="import" href="../../iron-icons/iron-icons.html">
   <link rel="import" href="../paper-tooltip.html">
+  <link rel="import" href="test-button.html">
 
   <style is="custom-style">
     .horizontal-section {
       min-width: 120px;
-      position: relative;
     }
 
     .with-tooltip {
@@ -44,6 +44,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       overflow: hidden;
       background: #ccc;
       margin: 0 auto 20px auto;
+      cursor: pointer;
     }
 
     .blue {
@@ -107,12 +108,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <div>
       <h4>Anchored to custom elements</h4>
       <div class="horizontal-section">
-        <paper-icon-button id="menu" icon="menu" alt="menu"></paper-icon-button>
+        <test-button></test-button>
         <paper-icon-button id="heart" icon="favorite" alt="heart"></paper-icon-button>
         <paper-icon-button id="back" icon="arrow-back" alt="go back"></paper-icon-button>
         <paper-icon-button id="fwd" icon="arrow-forward" alt="go forward"></paper-icon-button>
 
-        <paper-tooltip for="menu" margin-top="0">hot dogs</paper-tooltip>
         <paper-tooltip for="heart" margin-top="0">&lt;3 &lt;3 &lt;3 </paper-tooltip>
         <paper-tooltip for="back" margin-top="0">halp I am trapped in a tooltip</paper-tooltip>
         <paper-tooltip for="fwd" margin-top="0">back to the future</paper-tooltip>

--- a/demo/test-button.html
+++ b/demo/test-button.html
@@ -1,0 +1,36 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../paper-icon-button/paper-icon-button.html">
+<link rel="import" href="../../iron-icons/iron-icons.html">
+<link rel="import" href="../paper-tooltip.html">
+
+<dom-module id="test-button">
+  <style>
+    :host {
+      display: inline-block;
+    }
+
+    paper-icon-button {
+      padding: 0;
+    }
+  </style>
+  <template>
+    <paper-icon-button id="m" icon="menu" alt="menu"></paper-icon-button>
+    <paper-tooltip for="m" margin-top="8">hot dogs</paper-tooltip>
+  </template>
+
+  <script>
+    Polymer({
+      is: 'test-button'
+    });
+  </script>
+</dom-module>

--- a/paper-tooltip.html
+++ b/paper-tooltip.html
@@ -53,9 +53,11 @@ Custom property | Description | Default
       display: block;
       position: absolute;
       outline: none;
+      z-index: 1002;
     }
 
     #tooltip {
+      display: block;
       outline: none;
       @apply(--paper-font-common-base);
       font-size: 10px;
@@ -66,13 +68,17 @@ Custom property | Description | Default
 
       padding: 8px;
       border-radius: 2px;
-      z-index: 1002;
 
       @apply(--paper-tooltip);
     }
+
+    /* Thanks IE 10. */
+    .hidden {
+      display: none !important;
+    }
   </style>
   <template>
-    <div id="tooltip" hidden>
+    <div id="tooltip" class="hidden">
       <content></content>
     </div>
   </template>
@@ -95,7 +101,8 @@ Custom property | Description | Default
          * must be a sibling of the tooltip.
          */
         for: {
-          type: String
+          type: String,
+          observer: '_forChanged'
         },
 
         /**
@@ -140,16 +147,16 @@ Custom property | Description | Default
        * of the tooltip.
        */
       get target () {
-        var ownerRoot = Polymer.dom(this).getOwnerRoot();
         var parentNode = Polymer.dom(this).parentNode;
-        var target;
+        // If the parentNode is a document fragment, then we need to use the host.
+        var ownerRoot = Polymer.dom(this).getOwnerRoot();
 
+        var target;
         if (this.for) {
-          target = parentNode.querySelector('#' + this.for);
-        } else if (parentNode.nodeType == 11) { // DOCUMENT_FRAGMENT_NODE
-          target = ownerRoot.host;
+          target = Polymer.dom(ownerRoot).querySelector('#' + this.for);
         } else {
-          target = parentNode;
+          target = parentNode.nodeType == Node.DOCUMENT_FRAGMENT_NODE ?
+              ownerRoot.host : parentNode;
         }
 
         return target;
@@ -174,7 +181,12 @@ Custom property | Description | Default
       },
 
       show: function() {
-        this.$.tooltip.hidden = false;
+        if (this._showing)
+          return;
+
+        this.cancelAnimation();
+
+        this.toggleClass('hidden', false, this.$.tooltip);
         this._setPosition();
         this._showing = true;
 
@@ -182,8 +194,15 @@ Custom property | Description | Default
       },
 
       hide: function() {
+        if (!this._showing)
+          return;
+
         this._showing = false;
         this.playAnimation('exit');
+      },
+
+      _forChanged: function() {
+        this._target = this.target;
       },
 
       _setPosition: function() {
@@ -202,7 +221,7 @@ Custom property | Description | Default
 
       _onAnimationFinish: function() {
         if (!this._showing) {
-          this.$.tooltip.hidden = true;
+          this.toggleClass('hidden', true, this.$.tooltip);
         }
       },
     })

--- a/test/basic.html
+++ b/test/basic.html
@@ -21,8 +21,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../paper-tooltip.html">
+  <link rel="import" href="test-button.html">
 
 </head>
+<style>
+  body {
+    margin: 0;
+    padding: 0;
+  }
+  #target {
+    width: 100px;
+    height: 20px;
+    background-color: red;
+  }
+  paper-tooltip {
+    width: 70px;
+    height: 29px;
+  }
+</style>
+
 <body>
 
   <test-fixture id="basic">
@@ -34,38 +51,127 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="dynamic">
+    <template>
+      <div>
+        <div id="target"></div>
+        <paper-tooltip>Tooltip text</paper-tooltip>
+      </div>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="custom">
+    <template>
+      <test-button></test-button>
+    </template>
+  </test-fixture>
+
   <script>
+    function isHidden(element) {
+      var rect = element.getBoundingClientRect();
+      return (rect.width == 0 && rect.height == 0);
+    }
+
     suite('basic', function() {
-      var f, tooltip, target;
-
-      setup(function() {
-        f = fixture('basic');
-        target = f.querySelector('#target');
-        tooltip = f.querySelector('paper-tooltip');
-      });
-
       test('tooltip is shown when target is focused', function() {
+        var f = fixture('basic');
+        var target = f.querySelector('#target');
+        var tooltip = f.querySelector('paper-tooltip');
+
         var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
-        assert.isTrue(actualTooltip.hidden);
+        assert.isTrue(isHidden(actualTooltip));
 
         MockInteractions.focus(target);
-        assert.isFalse(actualTooltip.hidden);
+        assert.isFalse(isHidden(actualTooltip));
+      });
+
+      test('tooltip is positioned correctly', function() {
+        var f = fixture('basic');
+        var target = f.querySelector('#target');
+        var tooltip = f.querySelector('paper-tooltip');
+
+        var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
+        assert.isTrue(isHidden(actualTooltip));
+
+        MockInteractions.focus(target);
+        assert.isFalse(isHidden(actualTooltip));
+
+        var divRect = target.getBoundingClientRect();
+        expect(divRect.width).to.be.equal(100);
+        expect(divRect.height).to.be.equal(20);
+
+        var contentRect = tooltip.getBoundingClientRect();
+        expect(contentRect.width).to.be.equal(70);
+        expect(contentRect.height).to.be.equal(29);
+
+        // The target div width is 100, and the tooltip width is 70, and
+        // it's centered. The height of the target div is 20, and the
+        // tooltip is 14px below.
+        expect(contentRect.left).to.be.equal((100 - 70)/2);
+        expect(contentRect.top).to.be.equal(20 + 14);
+
+        // Also check the math, just in case.
+        expect(contentRect.left).to.be.equal((divRect.width - contentRect.width)/2);
+        expect(contentRect.top).to.be.equal(divRect.height + tooltip.marginTop);
+      });
+
+      test('tooltip is positioned correctly after being dynamically set', function() {
+        var f = fixture('dynamic');
+        var target = f.querySelector('#target');
+        var tooltip = f.querySelector('paper-tooltip');
+
+        var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
+        assert.isTrue(isHidden(actualTooltip));
+
+        // Skip animations in this test, which means we'll show and hide
+        // the tooltip manually, instead of calling focus and blur.
+
+        // The tooltip is shown because it's a sibling of the target,
+        // but it's positioned incorrectly
+        tooltip.toggleClass('hidden', false, actualTooltip);
+        assert.isFalse(isHidden(actualTooltip));
+
+        var contentRect = tooltip.getBoundingClientRect();
+        expect(contentRect.left).to.not.be.equal((100 - 70)/2);
+
+        tooltip.for = 'target';
+
+        // The tooltip needs to hide before it gets repositioned.
+        tooltip.toggleClass('hidden', true, actualTooltip);
+        tooltip._setPosition();
+        tooltip.toggleClass('hidden', false, actualTooltip);
+        assert.isFalse(isHidden(actualTooltip));
+
+        // The target div width is 100, and the tooltip width is 70, and
+        // it's centered. The height of the target div is 20, and the
+        // tooltip is 14px below.
+        contentRect = tooltip.getBoundingClientRect();
+        expect(contentRect.left).to.be.equal((100 - 70)/2);
+        expect(contentRect.top).to.be.equal(20 + 14);
       });
 
       test('tooltip is hidden after target is blurred', function(done) {
+        var f = fixture('basic');
+        var target = f.querySelector('#target');
+        var tooltip = f.querySelector('paper-tooltip');
+
         var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
-        assert.isTrue(actualTooltip.hidden);
+        assert.isTrue(isHidden(actualTooltip));
         MockInteractions.focus(target);
-        assert.isFalse(actualTooltip.hidden);
+        assert.isFalse(isHidden(actualTooltip));
 
         tooltip.addEventListener('neon-animation-finish', function() {
-          assert.isTrue(actualTooltip.hidden);
+          assert.isTrue(isHidden(actualTooltip));
           done();
         });
         MockInteractions.blur(target);
       });
 
       test('tooltip unlistens to target on detach', function(done) {
+        var f = fixture('basic');
+        var target = f.querySelector('#target');
+        var tooltip = f.querySelector('paper-tooltip');
+
         sinon.spy(tooltip, 'show');
 
         MockInteractions.focus(target);
@@ -82,6 +188,50 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(tooltip.show.callCount).to.be.equal(2);
           done();
         }, 200);
+      });
+    });
+
+    suite('tooltip is inside a custom element', function() {
+      var f, tooltip, target;
+
+      setup(function() {
+        f = fixture('custom');
+        target = f.$.button;
+        tooltip = f.$.tooltip;
+      });
+
+      test('tooltip is shown when target is focused', function() {
+        var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
+        assert.isTrue(isHidden(actualTooltip));
+
+        MockInteractions.focus(target);
+        assert.isFalse(isHidden(actualTooltip));
+      });
+
+      test('tooltip is positioned correctly', function() {
+        var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
+        assert.isTrue(isHidden(actualTooltip));
+
+        MockInteractions.focus(target);
+        assert.isFalse(isHidden(actualTooltip));
+
+        var divRect = target.getBoundingClientRect();
+        expect(divRect.width).to.be.equal(100);
+        expect(divRect.height).to.be.equal(20);
+
+        var contentRect = tooltip.getBoundingClientRect();
+        expect(contentRect.width).to.be.equal(70);
+        expect(contentRect.height).to.be.equal(29);
+
+        // The target div width is 100, and the tooltip width is 70, and
+        // it's centered. The height of the target div is 20, and the
+        // tooltip is 14px below.
+        expect(contentRect.left).to.be.equal((100 - 70)/2);
+        expect(contentRect.top).to.be.equal(20 + 14);
+
+        // Also check the math, just in case.
+        expect(contentRect.left).to.be.equal((divRect.width - contentRect.width)/2);
+        expect(contentRect.top).to.be.equal(divRect.height + tooltip.marginTop);
       });
     });
 

--- a/test/test-button.html
+++ b/test/test-button.html
@@ -1,0 +1,40 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../paper-tooltip.html">
+
+<dom-module id="test-button">
+  <style>
+    :host {
+      display: inline-block;
+    }
+
+    #button {
+      width: 100px;
+      height: 20px;
+      background-color: red;
+    }
+    paper-tooltip {
+      width: 70px;
+    }
+
+  </style>
+  <template>
+    <div id="button"></div>
+    <paper-tooltip id="tooltip" for="button">Tooltip text</paper-tooltip>
+  </template>
+
+  <script>
+    Polymer({
+      is: 'test-button'
+    });
+  </script>
+</dom-module>


### PR DESCRIPTION
- Fixes https://github.com/PolymerElements/paper-tooltip/issues/13 -- the animation was still happening on the second reshow, which makes the tooltip confused, so I cancel it for good measure
- Fixes https://github.com/PolymerElements/paper-tooltip/issues/7 -- `Polymer.dom(this).parentNode` is weird under `:root`. It gives the document fragment, not the actual node itself. I've played around with it in the shady and shadow dom, and I don't see `this.parentNode` giving the wrong result ever, though please shout if there's an obvious one I missed.
- Fixes https://github.com/PolymerElements/paper-tooltip/issues/18 and https://github.com/PolymerElements/paper-tooltip/issues/3 -- the `z-index` was in the wrong place.
- Fixes this not-working-at-all on IE10. Yeah, I just found out about how `hidden` is realllllllly not a thing.

/cc @morethanreal @cdata 