### PR TITLE
Fixes improper position while scrolling.

### DIFF
--- a/paper-tooltip.html
+++ b/paper-tooltip.html
@@ -215,8 +215,14 @@ Custom property | Description | Default
 
         var centerOffset = (targetRect.width - thisRect.width) / 2;
 
-        this.style.left = targetRect.left - parentRect.left + centerOffset + 'px';
-        this.style.top = targetRect.top - parentRect.top + targetRect.height + this.marginTop + 'px';
+        // The offsetParent may itself be scrollable, so top needs to be relative
+        // to its bounds, rather than the viewport.
+        var scrollLeft = this.offsetParent.scrollLeft;
+        var scrollTop = this.offsetParent.scrollTop;
+
+        this.style.left = targetRect.left - parentRect.left + scrollLeft + centerOffset + 'px';
+        this.style.top =
+          targetRect.top - parentRect.top + scrollTop + targetRect.height + this.marginTop + 'px';
       },
 
       _onAnimationFinish: function() {

--- a/test/basic.html
+++ b/test/basic.html
@@ -222,10 +222,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
         var tooltipBox = actualTooltip.getBoundingClientRect();
         var contentBox = content.getBoundingClientRect();
-        assert.operator(
-            tooltipBox.left + tooltipBox.width / 2,
-            '==',
-            contentBox.left + contentBox.width / 2);
+
+        var tooltipCenter = tooltipBox.left + tooltipBox.width / 2;
+        var contentCenter = contentBox.left + contentBox.width / 2;
+        // We really want to test equality but there appear to be some rounding errors
+        // when using shadow DOM.  Want to be within 1 pixel at least.
+        assert.operator(Math.abs(tooltipCenter - contentCenter), '<', 1);
       });
 
     });

--- a/test/basic.html
+++ b/test/basic.html
@@ -22,6 +22,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../paper-tooltip.html">
   <link rel="import" href="test-button.html">
+  <link rel="import" href="test-scroll.html">
 
 </head>
 <style>
@@ -57,6 +58,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <div id="target"></div>
         <paper-tooltip>Tooltip text</paper-tooltip>
       </div>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="scroll">
+    <template>
+      <test-scroll></test-scroll>
     </template>
   </test-fixture>
 
@@ -189,6 +196,38 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           done();
         }, 200);
       });
+    });
+
+    suite('tooltip is inside a scrollable element', function() {
+      var f, tooltip, content;
+
+      setup(function() {
+        f = fixture('scroll');
+        tooltip = f.$.tooltip;
+        content = f.$.content;
+      });
+
+      test('tooltip is below the content element if scrolled vertically', function() {
+        f.$.container.scrollTop = f.$.container.scrollHeight;
+        MockInteractions.focus(content);
+        var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
+        var tooltipBox = actualTooltip.getBoundingClientRect();
+        var contentBox = content.getBoundingClientRect();
+        assert.operator(tooltipBox.top, '>',  contentBox.top + contentBox.height);
+      });
+
+      test('tooltip is centered below the content element if scrolled horizontally', function() {
+        f.$.container.scrollLeft = f.$.container.scrollWidth;
+        MockInteractions.focus(content);
+        var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
+        var tooltipBox = actualTooltip.getBoundingClientRect();
+        var contentBox = content.getBoundingClientRect();
+        assert.operator(
+            tooltipBox.left + tooltipBox.width / 2,
+            '==',
+            contentBox.left + contentBox.width / 2);
+      });
+
     });
 
     suite('tooltip is inside a custom element', function() {

--- a/test/test-scroll.html
+++ b/test/test-scroll.html
@@ -1,0 +1,44 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../paper-tooltip.html">
+
+<dom-module id="test-scroll">
+  <style>
+    #container {
+      position: relative;
+      height: 150px;
+      width: 150px;
+      overflow-y: scroll;
+      overflow-x: scroll;
+    }
+
+    .other-content {
+      height: 100px;
+      width: 160px;
+    }
+  </style>
+  <template>
+    <div id="container">
+      <div class="other-content"></div>
+      <span id="content">Content</span>
+      <div class="other-content"></div>
+      <paper-tooltip id="tooltip" for="content">Tooltip text</paper-tooltip>
+    </div>
+  </template>
+
+  <script>
+    Polymer({
+      is: 'test-scroll',
+    });
+  </script>
+</dom-module>
+


### PR DESCRIPTION
This ensures that if the paper-tooltip's offsetParent is scrollable,
it includes the scrollTop and scrollLeft in the calculation of its
relative position.  Otherwise the tooltip will become progressively
more and more offset as the offsetParent is scrolled.

Fixes #24 