### PR TITLE
Adds a position attribute and bonus fixes

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -113,9 +113,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <paper-icon-button id="back" icon="arrow-back" alt="go back"></paper-icon-button>
         <paper-icon-button id="fwd" icon="arrow-forward" alt="go forward"></paper-icon-button>
 
-        <paper-tooltip for="heart" margin-top="0">&lt;3 &lt;3 &lt;3 </paper-tooltip>
-        <paper-tooltip for="back" margin-top="0">halp I am trapped in a tooltip</paper-tooltip>
-        <paper-tooltip for="fwd" margin-top="0">back to the future</paper-tooltip>
+        <!-- paper-icon-buttons have an inherent padding that will push the tooltip down. offset undoes it -->
+        <paper-tooltip for="heart" offset="0">&lt;3 &lt;3 &lt;3 </paper-tooltip>
+        <paper-tooltip for="back" offset="0">halp I am trapped in a tooltip</paper-tooltip>
+        <paper-tooltip for="fwd" offset="0">back to the future</paper-tooltip>
       </div>
     </div>
     <div>
@@ -126,19 +127,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <div id="green" class="avatar green" tabindex="0"></div>
         <div id="orange" class="avatar orange" tabindex="0"></div>
 
-        <paper-tooltip for="red" class="custom">
+        <paper-tooltip for="red" class="custom" position="left">
           <img src="http://i.imgur.com/OuUe8Da.jpg">
           Rich-text tooltips are doable but against the Material Design spec.
         </paper-tooltip>
-        <paper-tooltip for="blue" class="custom">
+        <paper-tooltip for="blue" class="custom" position="right">
           <img src="http://i.imgur.com/OuUe8Da.jpg">
           Rich-text tooltips are doable but against the Material Design spec.
         </paper-tooltip>
-        <paper-tooltip for="green" class="custom">
+        <paper-tooltip for="green" class="custom" position="top">
           <img src="http://i.imgur.com/OuUe8Da.jpg">
           Rich-text tooltips are doable but against the Material Design spec.
         </paper-tooltip>
-        <paper-tooltip for="orange" class="custom">
+        <paper-tooltip for="orange" class="custom" position="bottom">
           <img src="http://i.imgur.com/OuUe8Da.jpg">
           Rich-text tooltips are doable but against the Material Design spec.
         </paper-tooltip>

--- a/demo/test-button.html
+++ b/demo/test-button.html
@@ -25,7 +25,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </style>
   <template>
     <paper-icon-button id="m" icon="menu" alt="menu"></paper-icon-button>
-    <paper-tooltip for="m" margin-top="8">hot dogs</paper-tooltip>
+    <paper-tooltip for="m" offset="8">hot dogs</paper-tooltip>
   </template>
 
   <script>

--- a/paper-tooltip.html
+++ b/paper-tooltip.html
@@ -31,6 +31,12 @@ Example:
       <paper-tooltip for="btn">Tooltip text</paper-tooltip>
     </div>
 
+The tooltip can be positioned on the top|bottom|left|right of the anchor using
+the `position` attribute. The default position is bottom.
+
+    <paper-tooltip for="btn" position="left">Tooltip text</paper-tooltip>
+    <paper-tooltip for="btn" position="top">Tooltip text</paper-tooltip>
+
 ### Styling
 
 The following custom properties and mixins are available for styling:
@@ -106,8 +112,35 @@ Custom property | Description | Default
         },
 
         /**
+         * Positions the tooltip to the top, right, bottom, left of its content.
+         */
+        position: {
+          type: String,
+          value: 'bottom'
+        },
+
+        /**
+         * If true, no parts of the tooltip will ever be shown offscreen.
+         */
+        fitToVisibleBounds: {
+          type: Boolean,
+          value: false
+        },
+
+        /**
          * The spacing between the top of the tooltip and the element it is
          * anchored to.
+         */
+        offset: {
+          type: Number,
+          value: 14
+        },
+
+        /**
+         * This property is deprecated, but left over so that it doesn't
+         * break exiting code. Please use `offset` instead. If both `offset` and
+         * `marginTop` are provided, `marginTop` will be ignored.
+         * @deprecated since version 1.0.3
          */
         marginTop: {
           type: Number,
@@ -184,10 +217,13 @@ Custom property | Description | Default
         if (this._showing)
           return;
 
+        if (Polymer.dom(this).textContent.trim() === '')
+          return;
+
         this.cancelAnimation();
 
         this.toggleClass('hidden', false, this.$.tooltip);
-        this._setPosition();
+        this.updatePosition();
         this._showing = true;
 
         this.playAnimation('entry');
@@ -205,18 +241,70 @@ Custom property | Description | Default
         this._target = this.target;
       },
 
-      _setPosition: function() {
+      updatePosition: function() {
         if (!this._target)
           return;
+
+        var offset = this.offset;
+        // If a marginTop has been provided by the user (pre 1.0.3), use it.
+        if (this.marginTop != 14 && this.offset == 14)
+          offset = this.marginTop;
 
         var parentRect = this.offsetParent.getBoundingClientRect();
         var targetRect = this._target.getBoundingClientRect();
         var thisRect = this.getBoundingClientRect();
 
-        var centerOffset = (targetRect.width - thisRect.width) / 2;
+        var horizontalCenterOffset = (targetRect.width - thisRect.width) / 2;
+        var verticalCenterOffset = (targetRect.height - thisRect.height) / 2;
 
-        this.style.left = targetRect.left - parentRect.left + centerOffset + 'px';
-        this.style.top = targetRect.top - parentRect.top + targetRect.height + this.marginTop + 'px';
+        var targetLeft = targetRect.left - parentRect.left;
+        var targetTop = targetRect.top - parentRect.top;
+
+        var tooltipLeft, tooltipTop;
+
+        switch (this.position) {
+          case 'top':
+            tooltipLeft = targetLeft + horizontalCenterOffset;
+            tooltipTop = targetTop - thisRect.height - offset;
+            break;
+          case 'bottom':
+            tooltipLeft = targetLeft + horizontalCenterOffset;
+            tooltipTop = targetTop + targetRect.height + offset;
+            break;
+          case 'left':
+            tooltipLeft = targetLeft - thisRect.width - offset;
+            tooltipTop = targetTop + verticalCenterOffset;
+            break;
+          case 'right':
+            tooltipLeft = targetLeft + targetRect.width + offset;
+            tooltipTop = targetTop + verticalCenterOffset;
+            break;
+        }
+
+        // TODO(noms): This should use IronFitBehavior if possible.
+        if (this.fitToVisibleBounds) {
+          // Clip the left/right side.
+          if (tooltipLeft + thisRect.width > window.innerWidth) {
+            this.style.right = '0px';
+            this.style.left = 'auto';
+          } else {
+            this.style.left = Math.max(0, tooltipLeft) + 'px';
+            this.style.right = 'auto';
+          }
+
+          // Clip the top/bottom side.
+          if (tooltipTop + thisRect.height > window.innerHeight) {
+            this.style.bottom = '0px';
+            this.style.top = 'auto';
+          } else {
+            this.style.top = Math.max(0, tooltipTop) + 'px';
+            this.style.bottom = 'auto';
+          }
+        } else {
+          this.style.left = tooltipLeft + 'px';
+          this.style.top = tooltipTop + 'px';
+        }
+
       },
 
       _onAnimationFinish: function() {

--- a/test/basic.html
+++ b/test/basic.html
@@ -36,8 +36,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   }
   paper-tooltip {
     width: 70px;
-    height: 29px;
+    height: 30px;
   }
+
+  .wide {
+    width: 200px;
+  }
+
 </style>
 
 <body>
@@ -47,6 +52,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <div>
         <div id="target"></div>
         <paper-tooltip for="target">Tooltip text</paper-tooltip>
+      </div>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="fitted">
+    <template>
+      <div>
+        <div id="target" style="position:absolute"></div>
+        <paper-tooltip for="target" class="wide" fit-to-visible-bounds>Tooltip text</paper-tooltip>
+      </div>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="no-text">
+    <template>
+      <div>
+        <div id="target"></div>
+        <paper-tooltip for="target"></paper-tooltip>
       </div>
     </template>
   </test-fixture>
@@ -74,6 +97,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     suite('basic', function() {
       test('tooltip is shown when target is focused', function() {
+        var f = fixture('no-text');
+        var target = f.querySelector('#target');
+        var tooltip = f.querySelector('paper-tooltip');
+
+        var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
+        assert.isTrue(isHidden(actualTooltip));
+
+        MockInteractions.focus(target);
+        assert.isTrue(isHidden(actualTooltip));
+      });
+
+      test('tooltip is not shown if empty', function() {
         var f = fixture('basic');
         var target = f.querySelector('#target');
         var tooltip = f.querySelector('paper-tooltip');
@@ -85,7 +120,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.isFalse(isHidden(actualTooltip));
       });
 
-      test('tooltip is positioned correctly', function() {
+      test('tooltip is positioned correctly (bottom)', function() {
         var f = fixture('basic');
         var target = f.querySelector('#target');
         var tooltip = f.querySelector('paper-tooltip');
@@ -102,7 +137,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         var contentRect = tooltip.getBoundingClientRect();
         expect(contentRect.width).to.be.equal(70);
-        expect(contentRect.height).to.be.equal(29);
+        expect(contentRect.height).to.be.equal(30);
 
         // The target div width is 100, and the tooltip width is 70, and
         // it's centered. The height of the target div is 20, and the
@@ -112,7 +147,121 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         // Also check the math, just in case.
         expect(contentRect.left).to.be.equal((divRect.width - contentRect.width)/2);
-        expect(contentRect.top).to.be.equal(divRect.height + tooltip.marginTop);
+        expect(contentRect.top).to.be.equal(divRect.height + tooltip.offset);
+      });
+
+      test('tooltip is positioned correctly (top)', function() {
+        var f = fixture('basic');
+        var target = f.querySelector('#target');
+        var tooltip = f.querySelector('paper-tooltip');
+        tooltip.position = 'top';
+
+        var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
+        assert.isTrue(isHidden(actualTooltip));
+
+        MockInteractions.focus(target);
+        assert.isFalse(isHidden(actualTooltip));
+
+        var divRect = target.getBoundingClientRect();
+        expect(divRect.width).to.be.equal(100);
+        expect(divRect.height).to.be.equal(20);
+
+        var contentRect = tooltip.getBoundingClientRect();
+        expect(contentRect.width).to.be.equal(70);
+        expect(contentRect.height).to.be.equal(30);
+
+        // The target div width is 100, and the tooltip width is 70, and
+        // it's centered. The height of the tooltip is 30, and the
+        // tooltip is 14px above the target.
+        expect(contentRect.left).to.be.equal((100 - 70)/2);
+        expect(contentRect.top).to.be.equal(0 - 30 - 14);
+
+        // Also check the math, just in case.
+        expect(contentRect.left).to.be.equal((divRect.width - contentRect.width)/2);
+        expect(contentRect.top).to.be.equal(0 - contentRect.height - tooltip.offset);
+      });
+
+      test('tooltip is positioned correctly (right)', function() {
+        var f = fixture('basic');
+        var target = f.querySelector('#target');
+        var tooltip = f.querySelector('paper-tooltip');
+        tooltip.position = 'right';
+
+        var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
+        assert.isTrue(isHidden(actualTooltip));
+
+        MockInteractions.focus(target);
+        assert.isFalse(isHidden(actualTooltip));
+
+        var divRect = target.getBoundingClientRect();
+        expect(divRect.width).to.be.equal(100);
+        expect(divRect.height).to.be.equal(20);
+
+        var contentRect = tooltip.getBoundingClientRect();
+        expect(contentRect.width).to.be.equal(70);
+        expect(contentRect.height).to.be.equal(30);
+
+        // The target div width is 100, and the tooltip is 14px to the right.
+        // The target div height is 20, the height of the tooltip is 20px, and
+        // the tooltip is centered.
+        expect(contentRect.left).to.be.equal(100 + 14);
+        expect(contentRect.top).to.be.equal((20 - 30)/2);
+
+        // Also check the math, just in case.
+        expect(contentRect.left).to.be.equal(divRect.width + tooltip.offset);
+        expect(contentRect.top).to.be.equal((divRect.height - contentRect.height)/2);
+      });
+
+      test('tooltip is positioned correctly (left)', function() {
+        var f = fixture('basic');
+        var target = f.querySelector('#target');
+        var tooltip = f.querySelector('paper-tooltip');
+        tooltip.position = 'left';
+
+        var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
+        assert.isTrue(isHidden(actualTooltip));
+
+        MockInteractions.focus(target);
+        assert.isFalse(isHidden(actualTooltip));
+
+        var divRect = target.getBoundingClientRect();
+        expect(divRect.width).to.be.equal(100);
+        expect(divRect.height).to.be.equal(20);
+
+        var contentRect = tooltip.getBoundingClientRect();
+        expect(contentRect.width).to.be.equal(70);
+        expect(contentRect.height).to.be.equal(30);
+
+        // The tooltip width is 70px, and the tooltip is 14px to the left of the target.
+        // The target div height is 20, the height of the tooltip is 20px, and
+        // the tooltip is centered.
+        expect(contentRect.left).to.be.equal(0 - 70 - 14);
+        expect(contentRect.top).to.be.equal((20 - 30)/2);
+
+        // Also check the math, just in case.
+        expect(contentRect.left).to.be.equal(0 - contentRect.width - tooltip.offset);
+        expect(contentRect.top).to.be.equal((divRect.height - contentRect.height)/2);
+      });
+
+      test('tooltip is fitted correctly if out of bounds', function() {
+        var f = fixture('fitted');
+        var target = f.querySelector('#target');
+        var tooltip = f.querySelector('paper-tooltip');
+        target.style.top = 0;
+        target.style.left = 0;
+
+        var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
+        assert.isTrue(isHidden(actualTooltip));
+
+        MockInteractions.focus(target);
+        assert.isFalse(isHidden(actualTooltip));
+
+        var contentRect = tooltip.getBoundingClientRect();
+        var divRect = target.getBoundingClientRect();
+
+        // Should be fitted on the left side.
+        expect(contentRect.left).to.be.equal(0);
+        expect(contentRect.top).to.be.equal(divRect.height + tooltip.offset);
       });
 
       test('tooltip is positioned correctly after being dynamically set', function() {
@@ -138,7 +287,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         // The tooltip needs to hide before it gets repositioned.
         tooltip.toggleClass('hidden', true, actualTooltip);
-        tooltip._setPosition();
+        tooltip.updatePosition();
         tooltip.toggleClass('hidden', false, actualTooltip);
         assert.isFalse(isHidden(actualTooltip));
 
@@ -221,7 +370,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         var contentRect = tooltip.getBoundingClientRect();
         expect(contentRect.width).to.be.equal(70);
-        expect(contentRect.height).to.be.equal(29);
+        expect(contentRect.height).to.be.equal(30);
 
         // The target div width is 100, and the tooltip width is 70, and
         // it's centered. The height of the target div is 20, and the
@@ -231,7 +380,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         // Also check the math, just in case.
         expect(contentRect.left).to.be.equal((divRect.width - contentRect.width)/2);
-        expect(contentRect.top).to.be.equal(divRect.height + tooltip.marginTop);
+        expect(contentRect.top).to.be.equal(divRect.height + tooltip.offset);
       });
     });
 


### PR DESCRIPTION
- fixes https://github.com/PolymerElements/paper-tooltip/issues/20: adds top/left/bottom/right positions for a tooltip (Based off https://github.com/PolymerElements/paper-tooltip/pull/19l thanks @StephanieYHe!)
- adds an optional `clipToVisibleBounds` property so that the tooltip is never shown offscreen
- deprecates `marginTop` and renames it to `offset`
- the protected `_setPosition` becomes the public `updatePosition()`
- fixes https://github.com/PolymerElements/paper-tooltip/issues/23 by not displaying a tooltip if the contents are empty
