### PR TITLE
Fix for hide animation playing before show animation start

### DIFF
--- a/paper-tooltip.html
+++ b/paper-tooltip.html
@@ -136,7 +136,14 @@ Custom property | Description | Default
         _showing: {
           type: Boolean,
           value: false
-        }
+        },
+
+        _delaying: {
+          type: Boolean,
+          value: false
+        },
+
+        _timeout:Object
       },
 
       listeners: {
@@ -183,19 +190,29 @@ Custom property | Description | Default
       },
 
       show: function() {
-        if (this._showing)
+        if (this._showing || this._delaying)
           return;
 
         this.cancelAnimation();
 
         this.toggleClass('hidden', false, this.$.tooltip);
         this._setPosition();
-        this._showing = true;
+        this._delaying = true;
+        this._timeout = setTimeout((function(obj) { return function() { obj._delaying = false; obj._showing = true; }; })(this),this.animationConfig['entry'][0].timing.delay);
 
         this.playAnimation('entry');
       },
 
       hide: function() {
+        if (this._delaying)
+        {
+          this.toggleClass('hidden', true, this.$.tooltip);
+          this.cancelAnimation();
+          clearTimeout(this._timeout);
+          this._delaying = false;
+          return;
+        }
+
         if (!this._showing)
           return;
 


### PR DESCRIPTION
The bug was triggered by quickly moving the mouse over an element with a
tooltip.
If the mouse exited before the tooltip appeared, the hide animation
would play anyway, making the tooltip visible and fading it out. Instead
the tooltip should stay invisible.

We fix this by tracking whether the show animation has started playing,
and if it hasn't, canceling the animation rather than playing the hide
animation.