### PR TITLE
minor fixes

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -127,19 +127,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <div id="green" class="avatar green" tabindex="0"></div>
         <div id="orange" class="avatar orange" tabindex="0"></div>
 
-        <paper-tooltip for="red" class="custom" position="left">
+        <paper-tooltip for="red" class="custom" position="left" animation-delay="0">
           <img src="http://i.imgur.com/OuUe8Da.jpg">
           Rich-text tooltips are doable but against the Material Design spec.
         </paper-tooltip>
-        <paper-tooltip for="blue" class="custom" position="right">
+        <paper-tooltip for="blue" class="custom" position="right" animation-delay="0">
           <img src="http://i.imgur.com/OuUe8Da.jpg">
           Rich-text tooltips are doable but against the Material Design spec.
         </paper-tooltip>
-        <paper-tooltip for="green" class="custom" position="top">
+        <paper-tooltip for="green" class="custom" position="top" animation-delay="0">
           <img src="http://i.imgur.com/OuUe8Da.jpg">
           Rich-text tooltips are doable but against the Material Design spec.
         </paper-tooltip>
-        <paper-tooltip for="orange" class="custom" position="bottom">
+        <paper-tooltip for="orange" class="custom" position="bottom" animation-delay="0">
           <img src="http://i.imgur.com/OuUe8Da.jpg">
           Rich-text tooltips are doable but against the Material Design spec.
         </paper-tooltip>

--- a/paper-tooltip.html
+++ b/paper-tooltip.html
@@ -63,6 +63,11 @@ Custom property | Description | Default
         position: absolute;
         outline: none;
         z-index: 1002;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        -webkit-user-select: none;
+        user-select: none;
+        cursor: default;
       }
 
       #tooltip {
@@ -152,6 +157,20 @@ Custom property | Description | Default
           value: 14
         },
 
+        /**
+         * The delay that will be applied before the `entry` animation is
+         * played when showing the tooltip.
+         */
+        animationDelay: {
+          type: Number,
+          value: 500
+        },
+
+        /**
+         * The entry and exit animations that will be played when showing and
+         * hiding the tooltip. If you want to override this, you must ensure
+         * that your animationConfig has the exact format below.
+         */
         animationConfig: {
           type: Object,
           value: function() {
@@ -159,7 +178,7 @@ Custom property | Description | Default
               'entry': [{
                 name: 'fade-in-animation',
                 node: this,
-                timing: {delay: 500}
+                timing: {delay: 0}
               }],
               'exit': [{
                 name: 'fade-out-animation',
@@ -176,7 +195,8 @@ Custom property | Description | Default
       },
 
       listeners: {
-        'neon-animation-finish': '_onAnimationFinish'
+        'neon-animation-finish': '_onAnimationFinish',
+        'mouseenter': 'hide'
       },
 
       /**
@@ -207,6 +227,7 @@ Custom property | Description | Default
         this.listen(this._target, 'focus', 'show');
         this.listen(this._target, 'mouseleave', 'hide');
         this.listen(this._target, 'blur', 'hide');
+        this.listen(this._target, 'tap', 'hide');
       },
 
       detached: function() {
@@ -215,30 +236,46 @@ Custom property | Description | Default
           this.unlisten(this._target, 'focus', 'show');
           this.unlisten(this._target, 'mouseleave', 'hide');
           this.unlisten(this._target, 'blur', 'hide');
+          this.unlisten(this._target, 'tap', 'hide');
         }
       },
 
       show: function() {
+        // If the tooltip is already showing, there's nothing to do.
         if (this._showing)
           return;
 
         if (Polymer.dom(this).textContent.trim() === '')
           return;
 
-        this.cancelAnimation();
 
+        this.cancelAnimation();
+        this._showing = true;
         this.toggleClass('hidden', false, this.$.tooltip);
         this.updatePosition();
-        this._showing = true;
 
+        this.animationConfig.entry[0].timing.delay = this.animationDelay;
+        this._animationPlaying = true;
         this.playAnimation('entry');
       },
 
       hide: function() {
-        if (!this._showing)
+        // If the tooltip is already hidden, there's nothing to do.
+        if (!this._showing) {
           return;
+        }
+
+        // If the entry animation is still playing, don't try to play the exit
+        // animation since this will reset the opacity to 1. Just end the animation.
+        if (this._animationPlaying) {
+          this.cancelAnimation();
+          this._showing = false;
+          this._onAnimationFinish();
+          return;
+        }
 
         this._showing = false;
+        this._animationPlaying = true;
         this.playAnimation('exit');
       },
 
@@ -313,6 +350,7 @@ Custom property | Description | Default
       },
 
       _onAnimationFinish: function() {
+        this._animationPlaying = false;
         if (!this._showing) {
           this.toggleClass('hidden', true, this.$.tooltip);
         }

--- a/test/basic.html
+++ b/test/basic.html
@@ -51,7 +51,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <div>
         <div id="target"></div>
-        <paper-tooltip for="target">Tooltip text</paper-tooltip>
+        <paper-tooltip for="target" animation-delay="0">Tooltip text</paper-tooltip>
       </div>
     </template>
   </test-fixture>
@@ -306,7 +306,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
         assert.isTrue(isHidden(actualTooltip));
-        MockInteractions.focus(target);
+        // Simulate but don't actually run the entry animation.
+        tooltip.toggleClass('hidden', false, actualTooltip);
+        tooltip._showing = true;
         assert.isFalse(isHidden(actualTooltip));
 
         tooltip.addEventListener('neon-animation-finish', function() {
@@ -346,7 +348,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       setup(function() {
         f = fixture('custom');
         target = f.$.button;
-        tooltip = f.$.tooltip;
+        tooltip = f.$.buttonTooltip;
       });
 
       test('tooltip is shown when target is focused', function() {
@@ -391,6 +393,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         assert.isTrue(tooltip.getAttribute('role') == 'tooltip');
       });
+
+      a11ySuite('basic');
+      a11ySuite('fitted');
+      a11ySuite('no-text');
+      a11ySuite('dynamic');
+      a11ySuite('custom');
     });
   </script>
 </body>

--- a/test/test-button.html
+++ b/test/test-button.html
@@ -23,14 +23,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         height: 20px;
         background-color: red;
       }
+
       paper-tooltip {
         width: 70px;
+        height: 30px;
       }
 
     </style>
 
     <div id="button"></div>
-    <paper-tooltip id="tooltip" for="button">Tooltip text</paper-tooltip>
+    <paper-tooltip id="buttonTooltip" for="button">Tooltip text</paper-tooltip>
   </template>
 
   <script>


### PR DESCRIPTION
- added an `animationDelay` property to control the entry animation timing
- hide the tooltip if hovering over the tooltip (fixes https://github.com/PolymerElements/paper-tooltip/issues/35)
- hide the tooltip if the target is pressed
- made the tooltip text not selectable and fixed its cursor

Testing fixes:
- added the a11ySuite
- in the shady dom, we were doing some magical styling and clashing of names, so I fixed that.