### PR TITLE
bug fix for undefined timing field for animation config

### DIFF
--- a/paper-tooltip.html
+++ b/paper-tooltip.html
@@ -266,6 +266,7 @@ Custom property | Description | Default
         this.toggleClass('hidden', false, this.$.tooltip);
         this.updatePosition();
 
+        this.animationConfig.entry[0].timing = this.animationConfig.entry[0].timing || {};
         this.animationConfig.entry[0].timing.delay = this.animationDelay;
         this._animationPlaying = true;
         this.playAnimation('entry');


### PR DESCRIPTION
If custom entry/exit animation is declared via attributes, the generated animation config will not have the timing field.

This generate a "property of undefined object" error when trying to insert the animation delay value into the timing field.

Added a line to create an empty "timing" object if it does not exist.