### PR TITLE
Fix for inconsistent obfuscation of animationConfig.entry & animationConfig.exit.

### DIFF
--- a/paper-tooltip.html
+++ b/paper-tooltip.html
@@ -185,12 +185,12 @@ Custom property | Description | Default
           type: Object,
           value: function() {
             return {
-              'entry': [{
+              entry: [{
                 name: 'fade-in-animation',
                 node: this,
                 timing: {delay: 0}
               }],
-              'exit': [{
+              exit: [{
                 name: 'fade-out-animation',
                 node: this
               }]


### PR DESCRIPTION
Resolves JSCompiler errors due to entry() and exit() being obfuscated when invoked in show() but not when they are defined on animationConfig.