### PR TITLE
Adding Class binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
 # Dependencies
 bower_components/
-
-# Editor / IDE Configuration
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+# Dependencies
 bower_components/
+
+# Editor / IDE Configuration
+.idea/

--- a/paper-tooltip.html
+++ b/paper-tooltip.html
@@ -220,10 +220,16 @@ Custom property | Description | Default
 
         var target;
         if (this.for) {
-          target = Polymer.dom(ownerRoot).querySelector('#' + this.for);
+          if (Polymer.dom(ownerRoot).querySelector('#' + this.for)) {
+            target = [Polymer.dom(ownerRoot).querySelector('#' + this.for)];
+          } else if (Polymer.dom(ownerRoot).querySelectorAll('.' + this.for) && Polymer.dom(ownerRoot).querySelectorAll('.' + this.for).length > 0){
+            target = Polymer.dom(ownerRoot).querySelectorAll('.' + this.for);
+          } else {
+            target = undefined;
+          }
         } else {
-          target = parentNode.nodeType == Node.DOCUMENT_FRAGMENT_NODE ?
-              ownerRoot.host : parentNode;
+          target = [parentNode.nodeType == Node.DOCUMENT_FRAGMENT_NODE ?
+              ownerRoot.host : parentNode];
         }
 
         return target;
@@ -235,26 +241,36 @@ Custom property | Description | Default
         if (this.manualMode)
           return;
 
-        this.listen(this._target, 'mouseenter', 'show');
-        this.listen(this._target, 'focus', 'show');
-        this.listen(this._target, 'mouseleave', 'hide');
-        this.listen(this._target, 'blur', 'hide');
-        this.listen(this._target, 'tap', 'hide');
+        this._target.forEach(function(target) {
+          this.listen(target, 'mouseenter', 'show');
+          this.listen(target, 'focus', 'show');
+          this.listen(target, 'mouseleave', 'hide');
+          this.listen(target, 'blur', 'hide');
+          this.listen(target, 'tap', 'hide');
+        }.bind(this));
+
         this.listen(this, 'mouseenter', 'hide');
       },
 
       detached: function() {
         if (this._target && !this.manualMode) {
-          this.unlisten(this._target, 'mouseenter', 'show');
-          this.unlisten(this._target, 'focus', 'show');
-          this.unlisten(this._target, 'mouseleave', 'hide');
-          this.unlisten(this._target, 'blur', 'hide');
-          this.unlisten(this._target, 'tap', 'hide');
+          this._target.forEach(function(target) {
+            this.unlisten(target, 'mouseenter', 'show');
+            this.unlisten(target, 'focus', 'show');
+            this.unlisten(target, 'mouseleave', 'hide');
+            this.unlisten(target, 'blur', 'hide');
+            this.unlisten(target, 'tap', 'hide');
+          }.bind(this));
+
           this.unlisten(this, 'mouseenter', 'hide');
         }
       },
 
-      show: function() {
+      show: function(e) {
+        // if no target event is passed use the first element from the _target property as fallback
+        this._target = this.target;
+        var triggerTarget = e && e.target ? e.target : this._target[0];
+
         // If the tooltip is already showing, there's nothing to do.
         if (this._showing)
           return;
@@ -266,7 +282,7 @@ Custom property | Description | Default
         this.cancelAnimation();
         this._showing = true;
         this.toggleClass('hidden', false, this.$.tooltip);
-        this.updatePosition();
+        this.updatePosition(triggerTarget);
 
         this.animationConfig.entry[0].timing = this.animationConfig.entry[0].timing || {};
         this.animationConfig.entry[0].timing.delay = this.animationDelay;
@@ -298,8 +314,12 @@ Custom property | Description | Default
         this._target = this.target;
       },
 
-      updatePosition: function() {
-        if (!this._target || !this.offsetParent)
+      updatePosition: function(targetElement) {
+        // if no target is passed use the first element from the _target property as fallback
+        this._target = this.target;
+        var target = targetElement || this._target[0];
+
+        if (!target || !this.offsetParent)
           return;
 
         var offset = this.offset;
@@ -308,7 +328,7 @@ Custom property | Description | Default
           offset = this.marginTop;
 
         var parentRect = this.offsetParent.getBoundingClientRect();
-        var targetRect = this._target.getBoundingClientRect();
+        var targetRect = target.getBoundingClientRect();
         var thisRect = this.getBoundingClientRect();
 
         var horizontalCenterOffset = (targetRect.width - thisRect.width) / 2;

--- a/test/basic.html
+++ b/test/basic.html
@@ -29,7 +29,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     margin: 0;
     padding: 0;
   }
-  #target {
+  #target, #target1, #target2 {
     width: 100px;
     height: 20px;
     background-color: red;
@@ -100,6 +100,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </div>
     </template>
   </test-fixture>
+
+  <test-fixture id="class">
+    <template>
+      <div>
+        <div class="target" id="target1"></div>
+        <div class="target" id="target2"></div>
+        <paper-tooltip for="target" animation-delay="0">Tooltip text</paper-tooltip>
+      </div>
+    </template>
+  </test-fixture>
+
 
   <script>
     function isHidden(element) {
@@ -397,6 +408,122 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         expect(divRect.height).to.be.equal(20);
 
         var contentRect = tooltip.getBoundingClientRect();
+        expect(contentRect.width).to.be.equal(70);
+        expect(contentRect.height).to.be.equal(30);
+
+        // The target div width is 100, and the tooltip width is 70, and
+        // it's centered. The height of the target div is 20, and the
+        // tooltip is 14px below.
+        expect(contentRect.left).to.be.equal((100 - 70)/2);
+        expect(contentRect.top).to.be.equal(20 + 14);
+
+        // Also check the math, just in case.
+        expect(contentRect.left).to.be.equal((divRect.width - contentRect.width)/2);
+        expect(contentRect.top).to.be.equal(divRect.height + tooltip.offset);
+      });
+    });
+
+    suite("tooltip is applied to a class", function() {
+      test('tooltip is shown when a target is focused', function() {
+        var f = fixture('class');
+        var target1 = f.querySelector('#target1');
+        var target2 = f.querySelector('#target2');
+        var tooltip = f.querySelector('paper-tooltip');
+
+        var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
+        assert.isTrue(isHidden(actualTooltip));
+
+        MockInteractions.focus(target1);
+        assert.isFalse(isHidden(actualTooltip));
+        MockInteractions.blur(target1);
+
+        MockInteractions.focus(target2);
+        assert.isFalse(isHidden(actualTooltip));
+        MockInteractions.blur(target2);
+      });
+
+      test('tooltip is hidden after a target is blurred', function(done) {
+        var f = fixture('class');
+        var target = f.querySelector('#target1');
+        var tooltip = f.querySelector('paper-tooltip');
+
+        var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
+        assert.isTrue(isHidden(actualTooltip));
+        // Simulate but don't actually run the entry animation.
+        tooltip.toggleClass('hidden', false, actualTooltip);
+        tooltip._showing = true;
+        assert.isFalse(isHidden(actualTooltip));
+
+        tooltip.addEventListener('neon-animation-finish', function() {
+          assert.isTrue(isHidden(actualTooltip));
+          done();
+        });
+        MockInteractions.blur(target1);
+      });
+
+      test('tooltip unlistens to targets on detach', function(done) {
+        var f = fixture('class');
+        var target1 = f.querySelector('#target1');
+        var target2 = f.querySelector('#target2');
+        var tooltip = f.querySelector('paper-tooltip');
+
+        sinon.spy(tooltip, 'show');
+
+        MockInteractions.focus(target1);
+        expect(tooltip.show.callCount).to.be.equal(1);
+
+        MockInteractions.focus(target2);
+        expect(tooltip.show.callCount).to.be.equal(2);
+
+        f.removeChild(tooltip);
+
+        setTimeout(function() {
+          // No more listener means no more calling show.
+          MockInteractions.focus(target1);
+          MockInteractions.focus(target2);
+          expect(tooltip.show.callCount).to.be.equal(2);
+          done();
+        }, 200);
+      });
+
+      test('tooltip is positioned correctly', function() {
+        var f = fixture('class');
+        var target1 = f.querySelector('#target1');
+        var target2 = f.querySelector('#target2');
+        var tooltip = f.querySelector('paper-tooltip');
+
+        var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
+        assert.isTrue(isHidden(actualTooltip));
+
+        MockInteractions.focus(target1);
+        assert.isFalse(isHidden(actualTooltip));
+
+        var divRect = target1.getBoundingClientRect();
+        expect(divRect.width).to.be.equal(100);
+        expect(divRect.height).to.be.equal(20);
+
+        var contentRect = tooltip.getBoundingClientRect();
+        expect(contentRect.width).to.be.equal(70);
+        expect(contentRect.height).to.be.equal(30);
+
+        // The target div width is 100, and the tooltip width is 70, and
+        // it's centered. The height of the target div is 20, and the
+        // tooltip is 14px below.
+        expect(contentRect.left).to.be.equal((100 - 70)/2);
+        expect(contentRect.top).to.be.equal(20 + 14);
+
+        // Also check the math, just in case.
+        expect(contentRect.left).to.be.equal((divRect.width - contentRect.width)/2);
+        expect(contentRect.top).to.be.equal(divRect.height + tooltip.offset);
+
+        MockInteractions.blur(target1);
+
+        // Test the second target
+        divRect = target2.getBoundingClientRect();
+        expect(divRect.width).to.be.equal(100);
+        expect(divRect.height).to.be.equal(20);
+
+        contentRect = tooltip.getBoundingClientRect();
         expect(contentRect.width).to.be.equal(70);
         expect(contentRect.height).to.be.equal(30);
 


### PR DESCRIPTION
Fullfills #89 

The patch makes a binding of the tooltip to classes possible.
The Tooltip reacts to user actions on every element, which is bound by the specified class in the `for` property.
