### PR TITLE
Allow for custom element that passes <content> tag only

### DIFF
--- a/paper-tooltip.html
+++ b/paper-tooltip.html
@@ -244,8 +244,18 @@ Custom property | Description | Default
         if (this._showing)
           return;
 
-        if (Polymer.dom(this).textContent.trim() === '')
-          return;
+        if (Polymer.dom(this).textContent.trim() === ''){
+          // Check if effective children are also empty
+          var empty = true;
+          var effectiveChildren = Polymer.dom(this).getEffectiveChildNodes();
+          for(var i=0; i<effectiveChildren.length; i++){
+            if(effectiveChildren[i].textContent.trim() !== ''){
+              empty = false;
+              break;
+            }
+          }
+          if(empty) return;
+        }
 
 
         this.cancelAnimation();

--- a/test/basic.html
+++ b/test/basic.html
@@ -22,6 +22,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../paper-tooltip.html">
   <link rel="import" href="test-button.html">
+  <link rel="import" href="test-icon.html">
 
 </head>
 <style>
@@ -92,6 +93,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="custom-with-content">
+    <template>
+      <test-icon>Tooltip text</test-icon>
+    </template>
+  </test-fixture>
+
   <test-fixture id="no-offset-parent">
     <template>
       <div>
@@ -100,7 +107,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </div>
     </template>
   </test-fixture>
-  
+
   <test-fixture id="manual-mode">
     <template>
       <div>
@@ -375,27 +382,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           done();
         }, 200);
       });
-      
+
       test('tooltip ignores events in manual-mode', function() {
         var f = fixture('manual-mode');
-        
+
         var tooltip = f.querySelector('paper-tooltip');
         assert.isTrue(tooltip.manualMode);
-        
+
         tooltip.show();
         assert.isTrue(tooltip._showing);
-        
+
         sinon.spy(tooltip, 'hide');
-        
+
         tooltip.fire('mouseenter');
-        
+
         var target = f.querySelector('#target');
         target.dispatchEvent(new CustomEvent('mouseenter'));
         target.dispatchEvent(new CustomEvent('focus'));
         target.dispatchEvent(new CustomEvent('mouseleave'));
         target.dispatchEvent(new CustomEvent('blur'));
         target.dispatchEvent(new CustomEvent('tap'));
-        
+
         expect(tooltip.hide.callCount).to.be.equal(0);
       });
 
@@ -443,6 +450,50 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         f = fixture('custom');
         target = f.$.button;
         tooltip = f.$.buttonTooltip;
+      });
+
+      test('tooltip is shown when target is focused', function() {
+        var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
+        assert.isTrue(isHidden(actualTooltip));
+
+        MockInteractions.focus(target);
+        assert.isFalse(isHidden(actualTooltip));
+      });
+
+      test('tooltip is positioned correctly', function() {
+        var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
+        assert.isTrue(isHidden(actualTooltip));
+
+        MockInteractions.focus(target);
+        assert.isFalse(isHidden(actualTooltip));
+
+        var divRect = target.getBoundingClientRect();
+        expect(divRect.width).to.be.equal(100);
+        expect(divRect.height).to.be.equal(20);
+
+        var contentRect = tooltip.getBoundingClientRect();
+        expect(contentRect.width).to.be.equal(70);
+        expect(contentRect.height).to.be.equal(30);
+
+        // The target div width is 100, and the tooltip width is 70, and
+        // it's centered. The height of the target div is 20, and the
+        // tooltip is 14px below.
+        expect(contentRect.left).to.be.equal((100 - 70)/2);
+        expect(contentRect.top).to.be.equal(20 + 14);
+
+        // Also check the math, just in case.
+        expect(contentRect.left).to.be.equal((divRect.width - contentRect.width)/2);
+        expect(contentRect.top).to.be.equal(divRect.height + tooltip.offset);
+      });
+    });
+
+    suite('tooltip is inside a custom element with content', function() {
+      var f, tooltip, target;
+
+      setup(function() {
+        f = fixture('custom-with-content');
+        target = f.$.icon;
+        tooltip = f.$.iconTooltip;
       });
 
       test('tooltip is shown when target is focused', function() {

--- a/test/test-icon.html
+++ b/test/test-icon.html
@@ -1,0 +1,43 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../paper-tooltip.html">
+
+<dom-module id="test-icon">
+  <template>
+    <style>
+      :host {
+        display: inline-block;
+      }
+
+      #icon {
+        width: 100px;
+        height: 20px;
+        background-color: red;
+      }
+
+      paper-tooltip {
+        width: 70px;
+        height: 30px;
+      }
+
+    </style>
+
+    <div id="icon"></div>
+    <paper-tooltip id="iconTooltip" for="icon"><content></content></paper-tooltip>
+  </template>
+
+  <script>
+    Polymer({
+      is: 'test-icon'
+    });
+  </script>
+</dom-module>


### PR DESCRIPTION
Fixes #68 by checking if effective children are also empty.

Allows for a custom element that passes only `<content>` to the `<paper-tooltip>` parent allowing for something like:
`<custom-element>Tooltip text.</custom-element>`

Adds a test for a custom element with the `<content>` tag.

Created `test-icon.html` as the custom element mentioned above for testing.