### PR TITLE
Fix placement of tooltip when 'fitToVisibleBounds' is set

### DIFF
--- a/paper-tooltip.html
+++ b/paper-tooltip.html
@@ -321,8 +321,8 @@ Custom property | Description | Default
 
         // TODO(noms): This should use IronFitBehavior if possible.
         if (this.fitToVisibleBounds) {
-          // Clip the left/right side.
-          if (tooltipLeft + thisRect.width > window.innerWidth) {
+          // Clip the left/right side
+          if (parentRect.left + tooltipLeft + thisRect.width > window.innerWidth) {
             this.style.right = '0px';
             this.style.left = 'auto';
           } else {
@@ -331,11 +331,11 @@ Custom property | Description | Default
           }
 
           // Clip the top/bottom side.
-          if (tooltipTop + thisRect.height > window.innerHeight) {
-            this.style.bottom = '0px';
+          if (parentRect.top + tooltipTop + thisRect.height > window.innerHeight) {
+            this.style.bottom = parentRect.height + 'px';
             this.style.top = 'auto';
           } else {
-            this.style.top = Math.max(0, tooltipTop) + 'px';
+            this.style.top = Math.max(-parentRect.top, tooltipTop) + 'px';
             this.style.bottom = 'auto';
           }
         } else {


### PR DESCRIPTION
The current logic does not seem to correctly take into account
placement and dimensions of the parent element. This is specially
noticeable with large tooltip elements.