### PR TITLE
removed neon-animation

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,9 +21,7 @@
   "ignore": [],
   "dependencies": {
     "polymer": "Polymer/polymer#1.9 - 2",
-    "paper-styles": "PolymerElements/paper-styles#1 - 2",
-    "neon-animation": "PolymerElements/neon-animation#1 - 2",
-    "web-animations-js": "web-animations/web-animations-js#^2.2.0"
+    "paper-styles": "PolymerElements/paper-styles#1 - 2"
   },
   "devDependencies": {
     "web-component-tester": "^6.0.0",
@@ -31,14 +29,14 @@
     "iron-component-page": "PolymerElements/iron-component-page#1 - 2",
     "iron-demo-helpers": "polymerelements/iron-demo-helpers#1 - 2",
     "iron-test-helpers": "PolymerElements/iron-test-helpers#1 - 2",
-    "paper-icon-button": "PolymerElements/paper-icon-button#1 - 2"
+    "paper-icon-button": "PolymerElements/paper-icon-button#1 - 2",
+    "web-animations-js": "web-animations/web-animations-js#^2.2.0"
   },
   "variants": {
     "1.x": {
       "dependencies": {
         "polymer": "Polymer/polymer#^1.9",
-        "paper-styles": "PolymerElements/paper-styles#^1.0.0",
-        "neon-animation": "PolymerElements/neon-animation#^1.0.0"
+        "paper-styles": "PolymerElements/paper-styles#^1.0.0"
       },
       "devDependencies": {
         "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
@@ -46,7 +44,8 @@
         "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
         "iron-demo-helpers": "polymerelements/iron-demo-helpers#^1.0.0",
         "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
-        "paper-icon-button": "PolymerElements/paper-icon-button#^1.0.0"
+        "paper-icon-button": "PolymerElements/paper-icon-button#^1.0.0",
+        "web-animations-js": "web-animations/web-animations-js#^2.2.0"
       },
       "resolutions": {
         "webcomponentsjs": "^0.7"

--- a/paper-tooltip.html
+++ b/paper-tooltip.html
@@ -306,7 +306,7 @@ Custom property | Description | Default
 
         this._showing = false;
         this._animationPlaying = true;
-        var timing = this.animationConfig.entry[0].timing;
+        var timing = this.animationConfig.exit[0].timing;
 
         if (!timing.duration && timing.duration != 0) {
           // default duration for neon-animation defaults to 0 otherwise

--- a/paper-tooltip.html
+++ b/paper-tooltip.html
@@ -10,9 +10,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../neon-animation/neon-animation-runner-behavior.html">
-<link rel="import" href="../neon-animation/animations/fade-in-animation.html">
-<link rel="import" href="../neon-animation/animations/fade-out-animation.html">
 
 <!--
 Material design: [Tooltips](https://www.google.com/design/spec/components/tooltips.html)
@@ -25,7 +22,7 @@ you must explicitely include the `web-animations` polyfill if you want this
 element to work on browsers not implementing the WebAnimations spec.
 
 Example:
-    // polyfill 
+    // polyfill
     <link rel="import" href="../../neon-animation/web-animations.html">
 
     <div style="display:inline-block">
@@ -111,10 +108,6 @@ Custom property | Description | Default
         role: 'tooltip',
         tabindex: -1
       },
-
-      behaviors: [
-        Polymer.NeonAnimationRunnerBehavior
-      ],
 
       properties: {
         /**
@@ -206,6 +199,14 @@ Custom property | Description | Default
         _showing: {
           type: Boolean,
           value: false
+        },
+
+        __currentAnimation: {
+          type: Object
+        },
+
+        __boundOnFinish: {
+          type: Function
         }
       },
 
@@ -232,6 +233,12 @@ Custom property | Description | Default
         }
 
         return target;
+      },
+
+      ready: function() {
+        this.__boundOnFinish = function() {
+          this.fire('neon-animation-finish');
+        }.bind(this);
       },
 
       attached: function() {
@@ -263,16 +270,23 @@ Custom property | Description | Default
           }
         }
 
-
         this.cancelAnimation();
         this._showing = true;
         this.toggleClass('hidden', false, this.$.tooltip);
         this.updatePosition();
-
-        this.animationConfig.entry[0].timing = this.animationConfig.entry[0].timing || {};
-        this.animationConfig.entry[0].timing.delay = this.animationDelay;
         this._animationPlaying = true;
-        this.playAnimation('entry');
+        var timing = this.animationConfig.entry[0].timing;
+
+        if (!timing.duration && timing.duration != 0) {
+          // default duration for neon-animation defaults to 0 otherwise
+          timing.duration = 500;
+        }
+
+        this.__currentAnimation = this.animate([
+          { opacity: 0 },
+          { opacity: 1 }
+        ], timing);
+        this.__currentAnimation.onfinish = this.__boundOnFinish;
       },
 
       hide: function() {
@@ -292,7 +306,18 @@ Custom property | Description | Default
 
         this._showing = false;
         this._animationPlaying = true;
-        this.playAnimation('exit');
+        var timing = this.animationConfig.entry[0].timing;
+
+        if (!timing.duration && timing.duration != 0) {
+          // default duration for neon-animation defaults to 0 otherwise
+          timing.duration = 500;
+        }
+        this.__currentAnimation = this.animate([
+          { opacity: 1 },
+          { opacity: 0 }
+        ], timing);
+
+        this.__currentAnimation.onfinish = this.__boundOnFinish;
       },
 
       updatePosition: function() {
@@ -359,6 +384,12 @@ Custom property | Description | Default
           this.style.top = tooltipTop + 'px';
         }
 
+      },
+
+      cancelAnimation: function() {
+        if (this._animation) {
+          this._animation.cancel();
+        }
       },
 
       _addListeners: function() {

--- a/paper-tooltip.html
+++ b/paper-tooltip.html
@@ -275,7 +275,7 @@ Custom property | Description | Default
         this.toggleClass('hidden', false, this.$.tooltip);
         this.updatePosition();
         this._animationPlaying = true;
-        var timing = this.animationConfig.entry[0].timing;
+        var timing = this.animationConfig.entry[0].timing || {};
 
         if (!timing.duration && timing.duration != 0) {
           // default duration for neon-animation defaults to 0 otherwise
@@ -306,7 +306,7 @@ Custom property | Description | Default
 
         this._showing = false;
         this._animationPlaying = true;
-        var timing = this.animationConfig.exit[0].timing;
+        var timing = this.animationConfig.exit[0].timing || {};
 
         if (!timing.duration && timing.duration != 0) {
           // default duration for neon-animation defaults to 0 otherwise

--- a/test/basic.html
+++ b/test/basic.html
@@ -20,7 +20,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../iron-test-helpers/mock-interactions.js"></script>
 
   <link rel="import" href="../../test-fixture/test-fixture.html">
-  <link rel="import" href="../../neon-animation/web-animations.html">
+  <link rel="import" href="../../web-animations-js/web-animations-next-lite.min.html">
   <link rel="import" href="../paper-tooltip.html">
   <link rel="import" href="test-button.html">
   <link rel="import" href="test-icon.html">


### PR DESCRIPTION
addresses #109.

`KeyframeEffect` does not seem to be included in Chrome anymore. This is a workaround to the issue and starts the eventual weaning off of `neon-animation`

Still currently investigating as to why `KeyframeEffect` isn't a thing.