### PR TITLE
Use bracket access for 'entry' in animation config

### DIFF
--- a/paper-tooltip.html
+++ b/paper-tooltip.html
@@ -269,8 +269,8 @@ Custom property | Description | Default
         this.toggleClass('hidden', false, this.$.tooltip);
         this.updatePosition();
 
-        this.animationConfig.entry[0].timing = this.animationConfig.entry[0].timing || {};
-        this.animationConfig.entry[0].timing.delay = this.animationDelay;
+        this.animationConfig['entry'][0].timing = this.animationConfig['entry'][0].timing || {};
+        this.animationConfig['entry'][0].timing.delay = this.animationDelay;
         this._animationPlaying = true;
         this.playAnimation('entry');
       },


### PR DESCRIPTION
Using bracket access prevents an error using property renaming (where `.entry` would get renamed, and config, including the default, would not).