### PR TITLE
Issue #121 - Uses Deprecated neon-animation - remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,5 +58,10 @@ The following custom properties and mixins are available for styling:
 | `--paper-tooltip-opacity` | The opacity of the tooltip | `0.9` |
 | `--paper-tooltip-text-color` | The text color of the tooltip | `white` |
 | `--paper-tooltip` | Mixin applied to the tooltip | `{}` |
+| `--paper-tooltip-delay-in` | Delay before tooltip starts to fade in | `500` |
+| `--paper-tooltip-delay-out` | Delay before tooltip starts to fade out | `0` |
+| `--paper-tooltip-duration-in` | Timing for Animation when showing tooltip | `500` |
+| `--paper-tooltip-duration-out` | Timining for Animation when hiding tooltip | `0` |
+| `--paper-tooltip-animation` | Mixin applied to the tooltip animation | `{}` |
 
 

--- a/bower.json
+++ b/bower.json
@@ -21,9 +21,7 @@
   "ignore": [],
   "dependencies": {
     "polymer": "Polymer/polymer#1.9 - 2",
-    "paper-styles": "PolymerElements/paper-styles#1 - 2",
-    "neon-animation": "PolymerElements/neon-animation#1 - 2",
-    "web-animations-js": "web-animations/web-animations-js#^2.2.0"
+    "paper-styles": "PolymerElements/paper-styles#1 - 2"
   },
   "devDependencies": {
     "web-component-tester": "^6.0.0",

--- a/demo/index.html
+++ b/demo/index.html
@@ -21,7 +21,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../iron-icons/iron-icons.html">
   <link rel="import" href="../../paper-icon-button/paper-icon-button.html">
   <link rel="import" href="../../paper-styles/color.html">
-  <link rel="import" href="../../neon-animation/web-animations.html">
   <link rel="import" href="../paper-tooltip.html">
   <link rel="import" href="test-button.html">
 
@@ -68,7 +67,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <!-- paper-icon-buttons have an inherent padding that will push the tooltip down. offset undoes it -->
         <paper-tooltip for="id_1" offset="0">&lt;3 &lt;3 &lt;3 </paper-tooltip>
         <paper-tooltip for="id_2" offset="0">wake up!</paper-tooltip>
-        <paper-tooltip for="id_3" offset="0">halp I am trapped in a tooltip</paper-tooltip>
+        <paper-tooltip for="id_3" offset="0">help I am trapped in a tooltip</paper-tooltip>
         <paper-tooltip for="id_4" offset="0">meow!</paper-tooltip>
       </template>
     </demo-snippet>
@@ -130,6 +129,52 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <img src="./donuts.png">
           Rich-text tooltips are doable but against the Material Design spec.
         </paper-tooltip>
+      </template>
+    </demo-snippet>
+
+    <h3>Tooltips can have different animation's</h3>
+    <demo-snippet class="centered-demo">
+      <template>
+        <paper-icon-button id="demo5_icon1" icon="all-out" alt="clock" on-click="onClick"></paper-icon-button>
+        <paper-tooltip id="demo5_tooltip" for="demo5_icon1" animation-delay="500" animation-entry="scale-up-animation" animation-exit="scale-down-animation">
+          This grows rather than fades in
+        </paper-tooltip>
+      </template>
+    </demo-snippet>
+    
+
+    <h3>Tooltips can be opened and closed with playAnimation.</h3>
+    <demo-snippet class="centered-demo">
+      <template>
+        <custom-style>
+          <style is="custom-style">
+            .slowmo {
+              --paper-tooltip-duration-in: 5000ms;
+              --paper-tooltip-duration-out: 5000ms;
+            }
+          </style>
+        </custom-style>
+        <p>Slow motion tooltip, 5 seconds! You can change the time of the animation by using mixins.  
+          You can also control the animation by function <em>playAnimation</em>.  
+          You can use function <em>cancelAnimation</em> that will jump to the end of the Animation.  </p>
+        <button id="demo6_btn_startshow">Start Animation Show</button>
+        <button id="demo6_btn_starthide">Start Animation Hide</button>
+        <button id="demo6_btn_cancel">Animation Cancel</button>
+        <paper-icon-button id="demo6_icon1" icon="schedule" alt="clock" on-click="onClick"></paper-icon-button>
+        <paper-tooltip id="demo6_tooltip" for="demo6_icon1" class="slowmo" animation-delay="500">
+          Slow Motion Load - Click to complete straight away
+        </paper-tooltip>
+        <script>
+          demo6_btn_startshow.addEventListener('click',function() {
+            demo6_tooltip.playAnimation("entry");
+          });
+          demo6_btn_starthide.addEventListener('click',function() {
+            demo6_tooltip.playAnimation("exit");
+          });
+          demo6_btn_cancel.addEventListener('click',function() {
+            demo6_tooltip.cancelAnimation();
+          });
+        </script>
       </template>
     </demo-snippet>
   </div>

--- a/paper-tooltip.html
+++ b/paper-tooltip.html
@@ -10,51 +10,44 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../neon-animation/neon-animation-runner-behavior.html">
-<link rel="import" href="../neon-animation/animations/fade-in-animation.html">
-<link rel="import" href="../neon-animation/animations/fade-out-animation.html">
+
 
 <!--
 Material design: [Tooltips](https://www.google.com/design/spec/components/tooltips.html)
-
 `<paper-tooltip>` is a label that appears on hover and focus when the user
 hovers over an element with the cursor or with the keyboard. It will be centered
 to an anchor element specified in the `for` attribute, or, if that doesn't exist,
 centered to the parent node containing it. Note that as of `paper-tooltip#2.0.0`,
 you must explicitely include the `web-animations` polyfill if you want this
 element to work on browsers not implementing the WebAnimations spec.
-
 Example:
     // polyfill
     <link rel="import" href="../../neon-animation/web-animations.html">
-
     <div style="display:inline-block">
       <button>Click me!</button>
       <paper-tooltip>Tooltip text</paper-tooltip>
     </div>
-
     <div>
       <button id="btn">Click me!</button>
       <paper-tooltip for="btn">Tooltip text</paper-tooltip>
     </div>
-
 The tooltip can be positioned on the top|bottom|left|right of the anchor using
 the `position` attribute. The default position is bottom.
-
     <paper-tooltip for="btn" position="left">Tooltip text</paper-tooltip>
     <paper-tooltip for="btn" position="top">Tooltip text</paper-tooltip>
-
 ### Styling
-
 The following custom properties and mixins are available for styling:
-
 Custom property | Description | Default
 ----------------|-------------|----------
 `--paper-tooltip-background` | The background color of the tooltip | `#616161`
 `--paper-tooltip-opacity` | The opacity of the tooltip | `0.9`
 `--paper-tooltip-text-color` | The text color of the tooltip | `white`
 `--paper-tooltip` | Mixin applied to the tooltip | `{}`
-
+`--paper-tooltip-delay-in` | Delay before tooltip starts to fade in | `500`
+`--paper-tooltip-delay-out` | Delay before tooltip starts to fade out | `0`
+`--paper-tooltip-duration-in` | Timing for Animation when showing tooltip | `500`
+`--paper-tooltip-duration-out` | Timining for Animation when hiding tooltip | `0`
+`--paper-tooltip-animation` | Mixin applied to the tooltip animation | `{}`
 @group Paper Elements
 @element paper-tooltip
 @demo demo/index.html
@@ -81,18 +74,153 @@ Custom property | Description | Default
         @apply --paper-font-common-base;
         font-size: 10px;
         line-height: 1;
-
         background-color: var(--paper-tooltip-background, #616161);
-        opacity: var(--paper-tooltip-opacity, 0.9);
         color: var(--paper-tooltip-text-color, white);
-
         padding: 8px;
         border-radius: 2px;
-
         @apply --paper-tooltip;
       }
 
+      @keyframes keyFrameScaleUp {
+        0% {
+          transform: scale(0.0);
+        }
+        100% {
+          transform: scale(1.0);
+        }
+      }
+
+      @keyframes keyFrameScaleDown {
+        0% {
+          transform: scale(1.0);
+        }
+        100% {
+          transform: scale(0.0);
+        }
+      }
+
+      @keyframes keyFrameFadeInOpacity {
+        0% {
+          opacity: 0;
+        }
+        100% {
+          opacity: var(--paper-tooltip-opacity, 0.9);
+        }
+      }
+
+      @keyframes keyFrameFadeOutOpacity {
+        0% {
+          opacity: var(--paper-tooltip-opacity, 0.9);
+        }
+        100% {
+          opacity: 0;
+        }
+      }
+
+      @keyframes keyFrameSlideDownIn {
+        0% {
+          transform: translateY(-2000px);
+          opacity: 0;
+        }
+        10% {
+          opacity: 0.2;
+        }
+        100% {
+          transform: translateY(0);
+          opacity: var(--paper-tooltip-opacity, 0.9);
+        }
+      }
+
+      @keyframes keyFrameSlideDownOut {
+        0% {
+          transform: translateY(0);
+          opacity: var(--paper-tooltip-opacity, 0.9);
+        }
+        10% {
+          opacity: 0.2;
+        }
+        100% {
+          transform: translateY(-2000px);
+          opacity: 0;
+        }
+      }
+
+      .fade-in-animation {
+        opacity: 0;
+        animation-delay: var(--paper-tooltip-delay-in, 500ms);
+        animation-name: keyFrameFadeInOpacity;
+        animation-iteration-count: 1;
+        animation-timing-function: ease-in;
+        animation-duration: var(--paper-tooltip-duration-in, 500ms);
+        animation-fill-mode: forwards;
+        @apply --paper-tooltip-animation;
+      }
+
+      .fade-out-animation {
+        opacity: var(--paper-tooltip-opacity, 0.9);
+        animation-delay: var(--paper-tooltip-delay-out, 0ms);
+        animation-name: keyFrameFadeOutOpacity;
+        animation-iteration-count: 1;
+        animation-timing-function: ease-in;
+        animation-duration: var(--paper-tooltip-duration-out, 500ms);
+        animation-fill-mode: forwards;
+        @apply --paper-tooltip-animation;
+      }
+
+      .scale-up-animation {
+        transform: scale(0);
+        opacity: var(--paper-tooltip-opacity, 0.9);
+        animation-delay: var(--paper-tooltip-delay-in, 500ms);
+        animation-name: keyFrameScaleUp;
+        animation-iteration-count: 1;
+        animation-timing-function: ease-in;
+        animation-duration: var(--paper-tooltip-duration-in, 500ms);
+        animation-fill-mode: forwards;
+        @apply --paper-tooltip-animation;
+      }
+
+      .scale-down-animation {
+        transform: scale(1);
+        opacity: var(--paper-tooltip-opacity, 0.9);
+        animation-delay: var(--paper-tooltip-delay-out, 500ms);
+        animation-name: keyFrameScaleDown;
+        animation-iteration-count: 1;
+        animation-timing-function: ease-in;
+        animation-duration: var(--paper-tooltip-duration-out, 500ms);
+        animation-fill-mode: forwards;
+        @apply --paper-tooltip-animation;
+      }
+
+      .slide-down-animation {
+        transform: translateY(-2000px);
+        opacity: 0;
+        animation-delay: var(--paper-tooltip-delay-out, 500ms);
+        animation-name: keyFrameSlideDownIn;
+        animation-iteration-count: 1;
+        animation-timing-function: cubic-bezier(0.0, 0.0, 0.2, 1);
+        animation-duration: var(--paper-tooltip-duration-out, 500ms);
+        animation-fill-mode: forwards;
+        @apply --paper-tooltip-animation;
+      }
+
+      .slide-down-animation-out {
+        transform: translateY(0);
+        opacity: var(--paper-tooltip-opacity, 0.9);
+        animation-delay: var(--paper-tooltip-delay-out, 500ms);
+        animation-name: keyFrameSlideDownOut;
+        animation-iteration-count: 1;
+        animation-timing-function: cubic-bezier(0.4, 0.0, 1, 1);
+        animation-duration: var(--paper-tooltip-duration-out, 500ms);
+        animation-fill-mode: forwards;
+        @apply --paper-tooltip-animation;
+      }
+
+      .cancel-animation {
+        animation-delay: -30s;
+      }
+
       /* Thanks IE 10. */
+
       .hidden {
         display: none !important;
       }
@@ -106,16 +234,10 @@ Custom property | Description | Default
   <script>
     Polymer({
       is: 'paper-tooltip',
-
       hostAttributes: {
         role: 'tooltip',
         tabindex: -1
       },
-
-      behaviors: [
-        Polymer.NeonAnimationRunnerBehavior
-      ],
-
       properties: {
         /**
          * The id of the element that the tooltip is anchored to. This element
@@ -126,7 +248,6 @@ Custom property | Description | Default
           type: String,
           observer: '_findTarget'
         },
-
         /**
          * Set this to true if you want to manually control when the tooltip
          * is shown or hidden.
@@ -136,7 +257,6 @@ Custom property | Description | Default
           value: false,
           observer: '_manualModeChanged'
         },
-
         /**
          * Positions the tooltip to the top, right, bottom, left of its content.
          */
@@ -144,7 +264,6 @@ Custom property | Description | Default
           type: String,
           value: 'bottom'
         },
-
         /**
          * If true, no parts of the tooltip will ever be shown offscreen.
          */
@@ -152,7 +271,6 @@ Custom property | Description | Default
           type: Boolean,
           value: false
         },
-
         /**
          * The spacing between the top of the tooltip and the element it is
          * anchored to.
@@ -161,7 +279,6 @@ Custom property | Description | Default
           type: Number,
           value: 14
         },
-
         /**
          * This property is deprecated, but left over so that it doesn't
          * break exiting code. Please use `offset` instead. If both `offset` and
@@ -172,29 +289,56 @@ Custom property | Description | Default
           type: Number,
           value: 14
         },
-
         /**
          * The delay that will be applied before the `entry` animation is
          * played when showing the tooltip.
          */
         animationDelay: {
           type: Number,
-          value: 500
+          value: 500,
+          observer: '_delayChange'
         },
-
         /**
+         * The animation that will be played on entry.  This replaces the
+         * deprecated animationConfig.  Entries here will override the 
+         * animationConfig settings.  You can enter your own animation
+         * by setting it to the css class name.
+         */
+        animationEntry: {
+          type: String,
+          value: ""
+        },
+        /**
+         * The animation that will be played on exit.  This replaces the
+         * deprecated animationConfig.  Entries here will override the 
+         * animationConfig settings.  You can enter your own animation
+         * by setting it to the css class name.
+         */
+        animationExit: {
+          type: String,
+          value: ""
+        },
+        /**
+         * This property is deprecated.  Use --paper-tooltip-animation to change the animation.
+         * The entry and exit animations that will be played when showing and
+         * hiding the tooltip. If you want to override this, you must ensure
+         * that your animationConfig has the exact format below.
+         * @deprecated since version
+         *
          * The entry and exit animations that will be played when showing and
          * hiding the tooltip. If you want to override this, you must ensure
          * that your animationConfig has the exact format below.
          */
         animationConfig: {
           type: Object,
-          value: function() {
+          value: function () {
             return {
               'entry': [{
                 name: 'fade-in-animation',
                 node: this,
-                timing: {delay: 0}
+                timing: {
+                  delay: 0
+                }
               }],
               'exit': [{
                 name: 'fade-out-animation',
@@ -203,17 +347,14 @@ Custom property | Description | Default
             }
           }
         },
-
         _showing: {
           type: Boolean,
           value: false
         }
       },
-
       listeners: {
-        'neon-animation-finish': '_onAnimationFinish',
+        'webkitAnimationEnd': '_onAnimationEnd',
       },
-
       /**
        * Returns the target element that this tooltip is anchored to. It is
        * either the element given by the `for` attribute, or the immediate parent
@@ -221,19 +362,17 @@ Custom property | Description | Default
        *
        * @type {Node}
        */
-      get target () {
+      get target() {
         var parentNode = Polymer.dom(this).parentNode;
         // If the parentNode is a document fragment, then we need to use the host.
         var ownerRoot = Polymer.dom(this).getOwnerRoot();
-
         var target;
         if (this.for) {
           target = Polymer.dom(ownerRoot).querySelector('#' + this.for);
         } else {
           target = parentNode.nodeType == Node.DOCUMENT_FRAGMENT_NODE ?
-              ownerRoot.host : parentNode;
+            ownerRoot.host : parentNode;
         }
-
         return target;
       },
 
@@ -253,14 +392,36 @@ Custom property | Description | Default
       },
 
       /**
+       * Replaces Neon-Animation playAnimation - just calls show and hide.
+       * @deprecated Use show and hide instead.
+       * @param {string} type Either `entry` or `exit`
+       */
+      playAnimation: function (type) {
+        if (type === "entry") {
+          this.show();
+        } else if (type === "exit") {
+          this.hide();
+        }
+      },
+
+      /**
+       * Cancels the animation and either fully shows or fully hides tooltip
+       */
+      cancelAnimation: function () {
+        // Short-cut and cancel all animations and hide
+        this.$.tooltip.classList.add('cancel-animation');
+      },
+      
+      /**
+       * Shows the tooltip programatically
        * @return {void}
        */
-      show: function() {
+      show: function () {
         // If the tooltip is already showing, there's nothing to do.
         if (this._showing)
           return;
 
-        if (Polymer.dom(this).textContent.trim() === ''){
+        if (Polymer.dom(this).textContent.trim() === '') {
           // Check if effective children are also empty
           var allChildrenEmpty = true;
           var effectiveChildren = Polymer.dom(this).getEffectiveChildNodes();
@@ -275,22 +436,20 @@ Custom property | Description | Default
           }
         }
 
-
-        this.cancelAnimation();
         this._showing = true;
-        this.toggleClass('hidden', false, this.$.tooltip);
+        this.$.tooltip.classList.remove('hidden');
+        this.$.tooltip.classList.remove('cancel-animation');
+        this.$.tooltip.classList.remove(this._getAnimationType('exit'));
         this.updatePosition();
-
-        this.animationConfig['entry'][0].timing = this.animationConfig['entry'][0].timing || {};
-        this.animationConfig['entry'][0].timing.delay = this.animationDelay;
         this._animationPlaying = true;
-        this.playAnimation('entry');
+        this.$.tooltip.classList.add(this._getAnimationType('entry'));
       },
 
       /**
+       * Hides the tooltip programatically
        * @return {void}
        */
-      hide: function() {
+      hide: function () {
         // If the tooltip is already hidden, there's nothing to do.
         if (!this._showing) {
           return;
@@ -299,15 +458,16 @@ Custom property | Description | Default
         // If the entry animation is still playing, don't try to play the exit
         // animation since this will reset the opacity to 1. Just end the animation.
         if (this._animationPlaying) {
-          this.cancelAnimation();
           this._showing = false;
-          this._onAnimationFinish();
+          this._cancelAnimation();
           return;
+        } else {
+          // Play Exit Animation
+          this._onAnimationFinish();
         }
 
         this._showing = false;
         this._animationPlaying = true;
-        this.playAnimation('exit');
       },
 
       /**
@@ -316,24 +476,18 @@ Custom property | Description | Default
       updatePosition: function() {
         if (!this._target || !this.offsetParent)
           return;
-
         var offset = this.offset;
         // If a marginTop has been provided by the user (pre 1.0.3), use it.
         if (this.marginTop != 14 && this.offset == 14)
           offset = this.marginTop;
-
         var parentRect = this.offsetParent.getBoundingClientRect();
         var targetRect = this._target.getBoundingClientRect();
         var thisRect = this.getBoundingClientRect();
-
         var horizontalCenterOffset = (targetRect.width - thisRect.width) / 2;
         var verticalCenterOffset = (targetRect.height - thisRect.height) / 2;
-
         var targetLeft = targetRect.left - parentRect.left;
         var targetTop = targetRect.top - parentRect.top;
-
         var tooltipLeft, tooltipTop;
-
         switch (this.position) {
           case 'top':
             tooltipLeft = targetLeft + horizontalCenterOffset;
@@ -352,7 +506,6 @@ Custom property | Description | Default
             tooltipTop = targetTop + verticalCenterOffset;
             break;
         }
-
         // TODO(noms): This should use IronFitBehavior if possible.
         if (this.fitToVisibleBounds) {
           // Clip the left/right side
@@ -363,7 +516,6 @@ Custom property | Description | Default
             this.style.left = Math.max(0, tooltipLeft) + 'px';
             this.style.right = 'auto';
           }
-
           // Clip the top/bottom side.
           if (parentRect.top + tooltipTop + thisRect.height > window.innerHeight) {
             this.style.bottom = parentRect.height + 'px';
@@ -376,10 +528,8 @@ Custom property | Description | Default
           this.style.left = tooltipLeft + 'px';
           this.style.top = tooltipTop + 'px';
         }
-
       },
-
-      _addListeners: function() {
+      _addListeners: function () {
         if (this._target) {
           this.listen(this._target, 'mouseenter', 'show');
           this.listen(this._target, 'focus', 'show');
@@ -387,34 +537,82 @@ Custom property | Description | Default
           this.listen(this._target, 'blur', 'hide');
           this.listen(this._target, 'tap', 'hide');
         }
+        this.listen(this.$.tooltip, 'animationend', '_onAnimationEnd');
         this.listen(this, 'mouseenter', 'hide');
       },
-
-      _findTarget: function() {
+      _findTarget: function () {
         if (!this.manualMode)
           this._removeListeners();
-
         this._target = this.target;
-
         if (!this.manualMode)
           this._addListeners();
       },
-
-      _manualModeChanged: function() {
+      _delayChange: function (newValue) {
+        // Only Update delay if different value set
+        if (newValue !== 500) {
+          this.updateStyles({
+            '--paper-tooltip-delay-in': newValue + "ms"
+          });
+        }
+      },
+      _manualModeChanged: function () {
         if (this.manualMode)
           this._removeListeners();
         else
           this._addListeners();
       },
-
-      _onAnimationFinish: function() {
-        this._animationPlaying = false;
-        if (!this._showing) {
-          this.toggleClass('hidden', true, this.$.tooltip);
+      _cancelAnimation: function () {
+        // Short-cut and cancel all animations and hide
+        this.$.tooltip.classList.remove(this._getAnimationType('entry'));
+        this.$.tooltip.classList.remove(this._getAnimationType('exit'));
+        this.$.tooltip.classList.remove('cancel-animation');
+        this.$.tooltip.classList.add('hidden');
+      },
+      _onAnimationFinish: function () {
+        if (this._showing) {
+          this.$.tooltip.classList.remove(this._getAnimationType('entry'));
+          this.$.tooltip.classList.remove('cancel-animation');
+          this.$.tooltip.classList.add(this._getAnimationType('exit'));
         }
       },
-
-      _removeListeners: function() {
+      _onAnimationEnd: function () {
+        // If no longer showing add class hidden to completely hide tooltip
+        this._animationPlaying = false;
+        if (!this._showing) {
+          this.$.tooltip.classList.remove(this._getAnimationType('exit'));
+          this.$.tooltip.classList.add('hidden');
+        }
+      },
+      _getAnimationType: function (type) {
+        // These properties have priority over animationConfig values
+        if ((type === 'entry') && (this.animationEntry !== '')) {
+          return this.animationEntry;
+        }
+        if ((type === 'exit') && (this.animationExit !== '')) {
+          return this.animationExit;
+        }
+        // If no results then return the legacy value from animationConfig
+        if (this.animationConfig[type] && typeof this.animationConfig[type][0].name === 'string') {
+          // Checking Timing and Update if necessary - Legacy for animationConfig
+          if (this.animationConfig[type][0].timing &&
+            this.animationConfig[type][0].timing.delay &&
+            this.animationConfig[type][0].timing.delay !== 0) {
+            var timingDelay = this.animationConfig[type][0].timing.delay;
+            // Has Timing Change - Update CSS
+            if (type === 'entry') {
+              this.updateStyles({
+                '--paper-tooltip-delay-in': timingDelay + "ms"
+              });
+            } else if (type === 'exit') {
+              this.updateStyles({
+                '--paper-tooltip-delay-out': timingDelay + "ms"
+              });
+            }
+          }
+          return this.animationConfig[type][0].name;
+        }
+      },
+      _removeListeners: function () {
         if (this._target) {
           this.unlisten(this._target, 'mouseenter', 'show');
           this.unlisten(this._target, 'focus', 'show');
@@ -422,6 +620,7 @@ Custom property | Description | Default
           this.unlisten(this._target, 'blur', 'hide');
           this.unlisten(this._target, 'tap', 'hide');
         }
+        this.unlisten(this.$.tooltip, 'animationend', '_onAnimationEnd');
         this.unlisten(this, 'mouseenter', 'hide');
       }
     });

--- a/paper-tooltip.html
+++ b/paper-tooltip.html
@@ -216,7 +216,7 @@ Custom property | Description | Default
       }
 
       .cancel-animation {
-        animation-delay: -30s;
+        animation-delay: -30s !important;
       }
 
       /* Thanks IE 10. */
@@ -371,7 +371,7 @@ Custom property | Description | Default
           target = Polymer.dom(ownerRoot).querySelector('#' + this.for);
         } else {
           target = parentNode.nodeType == Node.DOCUMENT_FRAGMENT_NODE ?
-            ownerRoot.host : parentNode;
+              ownerRoot.host : parentNode;
         }
         return target;
       },
@@ -379,14 +379,14 @@ Custom property | Description | Default
       /**
        * @return {void}
        */
-      attached: function() {
+      attached: function () {
         this._findTarget();
       },
 
       /**
        * @return {void}
        */
-      detached: function() {
+      detached: function () {
         if (!this.manualMode)
           this._removeListeners();
       },
@@ -411,7 +411,7 @@ Custom property | Description | Default
         // Short-cut and cancel all animations and hide
         this.$.tooltip.classList.add('cancel-animation');
       },
-      
+
       /**
        * Shows the tooltip programatically
        * @return {void}
@@ -473,7 +473,7 @@ Custom property | Description | Default
       /**
        * @return {void}
        */
-      updatePosition: function() {
+      updatePosition: function () {
         if (!this._target || !this.offsetParent)
           return;
         var offset = this.offset;

--- a/test/basic.html
+++ b/test/basic.html
@@ -20,7 +20,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../iron-test-helpers/mock-interactions.js"></script>
 
   <link rel="import" href="../../test-fixture/test-fixture.html">
-  <link rel="import" href="../../neon-animation/web-animations.html">
   <link rel="import" href="../paper-tooltip.html">
   <link rel="import" href="test-button.html">
   <link rel="import" href="test-icon.html">
@@ -39,6 +38,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   paper-tooltip {
     width: 70px;
     height: 30px;
+    /*
+       Added as hidden attribute is only set after duration in.  Thus if tested
+       too quickly after loss of focus tooltip will not be hidden.  Rather than
+       delaying tests, making the delay 0ms will hide immediately.
+    */
+    --paper-tooltip-duration-in: 0ms;
+    --paper-tooltip-duration-out: 0ms;
+    --paper-tooltip-delay-in: 0ms;
+    --paper-tooltip-delay-out: 0ms;
   }
 
   .wide {
@@ -123,6 +131,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var rect = element.getBoundingClientRect();
       return (rect.width == 0 && rect.height == 0);
     }
+    // Short sleep function
+    function sleep (time) {
+        return new Promise((resolve) => setTimeout(resolve, time));
+    }
 
     suite('basic', function() {
       test('tooltip is shown when target is focused', function() {
@@ -147,6 +159,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         MockInteractions.focus(target);
         assert.isFalse(isHidden(actualTooltip));
+      });
+
+      test('tooltip responds to playAnimation and cancelAnimation', function() {
+          var f = fixture('basic');
+          var target = f.querySelector('#target');
+          var tooltip = f.querySelector('paper-tooltip');
+
+          var actualTooltip = Polymer.dom(tooltip.root).querySelector('#tooltip');
+          assert.isTrue(isHidden(actualTooltip));
+
+          // This function is called by some applications directly - check it works
+          tooltip.playAnimation();
+          // Tooltip should now be shown
+          assert.isTrue(isHidden(actualTooltip));
+
+          // This function is called by some applications directly - check it works.
+          tooltip.cancelAnimation();
+          // Tooltip should now be hidden
+          assert.isTrue(isHidden(actualTooltip));
       });
 
       test('tooltip doesn\'t throw an exception if it has no offsetParent', function() {
@@ -342,7 +373,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         expect(contentRect.top).to.be.equal(20 + 14);
       });
 
-      test('tooltip is hidden after target is blurred', function(done) {
+      test('tooltip is hidden after target is blurred', function() {
         var f = fixture('basic');
         var target = f.querySelector('#target');
         var tooltip = f.querySelector('paper-tooltip');
@@ -352,13 +383,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Simulate but don't actually run the entry animation.
         tooltip.toggleClass('hidden', false, actualTooltip);
         tooltip._showing = true;
+        // This would also normally be set when used in the normal way
+        tooltip._animationPlaying = true;
         assert.isFalse(isHidden(actualTooltip));
 
-        tooltip.addEventListener('neon-animation-finish', function() {
-          assert.isTrue(isHidden(actualTooltip));
-          done();
-        });
         MockInteractions.blur(target);
+        assert.isTrue(isHidden(actualTooltip));
       });
 
       test('tooltip unlistens to target on detach', function(done) {


### PR DESCRIPTION
## Deprecated neon-animation

Fixes #121 

Component currently uses the neon-animation component which shows at https://www.webcomponents.org/element/PolymerElements/neon-animation to be deprecated.  Neon-animation component page recommends that we use web animations API or CSS animations as a replacement. I have chosen the **CSS Animations** route.  

## Overview of Changes

Uses simple CSS animation.  Adds --paper-tooltip-delay so that delay can be set externally.  Uses updateStyles so that this value can still be set by properties.  However default works well and now allows this value to be styled.
 
## ES6

I have also taken the opportunity to upgrade the object to Polymer 2.0 ES6 rather than hybrid.

## Tests

Default Demo's continue to work.  